### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,23 +6,23 @@
 # Datatypes (KEYWORD1)
 ###########################################
 
-FRAM_MB85RS_SPI KEYWORD1
+FRAM_MB85RS_SPI	KEYWORD1
 
 ###########################################
 # Methods and Functions (KEYWORD2)
 ###########################################
-init           	KEYWORD2
+init	KEYWORD2
 checkDevice		KEYWORD2
-isAvailable     KEYWORD2
+isAvailable	KEYWORD2
 getWPStatus		KEYWORD2
 enableWP		KEYWORD2
 disableWP		KEYWORD2
-read            KEYWORD2
-write           KEYWORD2
-readArray       KEYWORD2
-writeArray      KEYWORD2
-eraseChip       KEYOWRD2
-getMaxMemAdr    KEYWORD2
+read	KEYWORD2
+write	KEYWORD2
+readArray	KEYWORD2
+writeArray	KEYWORD2
+eraseChip	KEYWORD2
+getMaxMemAdr	KEYWORD2
 
 ###########################################
 # Constants (LITERAL1)
@@ -34,12 +34,12 @@ DENSITY_MB85RS_512	LITERAL1
 DENSITY_MB85RS_1024	LITERAL1
 DENSITY_MB85RS_2048	LITERAL1
 
-FRAM_WRSR		LITERAL1
-FRAM_WRITE		LITERAL1
-FRAM_READ		LITERAL1
-FRAM_WRDI		LITERAL1
-FRAM_RDSR		LITERAL1
-FRAM_WREN		LITERAL1
-FRAM_FSTRD		LITERAL1
-FRAM_RDID		LITERAL1
-FRAM_SLEEP		LITERAL1
+FRAM_WRSR	LITERAL1
+FRAM_WRITE	LITERAL1
+FRAM_READ	LITERAL1
+FRAM_WRDI	LITERAL1
+FRAM_RDSR	LITERAL1
+FRAM_WREN	LITERAL1
+FRAM_FSTRD	LITERAL1
+FRAM_RDID	LITERAL1
+FRAM_SLEEP	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords