### PR TITLE
Update FRAM_MB85RS_SPI.cpp

### DIFF
--- a/FRAM_MB85RS_SPI.cpp
+++ b/FRAM_MB85RS_SPI.cpp
@@ -248,7 +248,7 @@ boolean FRAM_MB85RS_SPI::read( uint32_t framAddr, uint32_t *value )
         buffer[3] = SPI.transfer(0);
     _csRELEASE();
    
-    *value = ( (uint32_t)buffer[2] << 16) + ((uint32_t)buffer[1] << 8) + (uint32_t)buffer[0];
+    *value = ((uint32_t)buffer[3] << 24) + ((uint32_t)buffer[2] << 16) + ((uint32_t)buffer[1] << 8) + (uint32_t)buffer[0];
     
     _lastaddress = framAddr+4;
     

--- a/FRAM_MB85RS_SPI.cpp
+++ b/FRAM_MB85RS_SPI.cpp
@@ -835,8 +835,9 @@ boolean FRAM_MB85RS_SPI::_deviceID2Serial()
 **/
 void FRAM_MB85RS_SPI::_setMemAddr( uint32_t *framAddr )
 {
-    SPI.transfer(*framAddr & 0xFF);  // MSB, Bits 0 to 7
-    SPI.transfer((*framAddr >> 8) & 0xFF);    // Bits 8 to 15
+    SPI.transfer((*framAddr >> 8) & 0xFF);    // MSB Bits 8 to 15
+    SPI.transfer(*framAddr & 0xFF);  //  Bits 0 to 7
+
     if (_densitycode >= DENSITY_MB85RS1MT)
         SPI.transfer((*framAddr >> 16) & 0xFF);  // Bits 16 to 23
     


### PR DESCRIPTION
Switched order that Address is transferred in _setMemAddr function. It was reversed which caused the library to write to address in wrong locations.